### PR TITLE
Look for explicitly defined FILER_UPLOADER_CONNECTIONS first

### DIFF
--- a/filer/settings.py
+++ b/filer/settings.py
@@ -235,12 +235,14 @@ FILER_PRIVATEMEDIA_SERVER = load_object(FILER_SERVERS['private']['main']['ENGINE
 FILER_PRIVATEMEDIA_THUMBNAIL_SERVER = load_object(FILER_SERVERS['private']['thumbnails']['ENGINE'])(**FILER_SERVERS['private']['thumbnails']['OPTIONS'])
 
 # By default limit number of simultaneous uploads if we are using SQLite
-if settings.DATABASES['default']['ENGINE'].endswith('sqlite3'):
-    _uploader_connections = 1
-else:
-    _uploader_connections = 3
 FILER_UPLOADER_CONNECTIONS = getattr(
-    settings, 'FILER_UPLOADER_CONNECTIONS', _uploader_connections)
+    settings, 'FILER_UPLOADER_CONNECTIONS', None)
+
+if FILER_UPLOADER_CONNECTIONS is None:
+    if settings.DATABASES and settings.DATABASES['default']['ENGINE'].endswith('sqlite3'):
+        FILER_UPLOADER_CONNECTIONS = 1
+    else:
+        FILER_UPLOADER_CONNECTIONS = 3
 
 FILER_DUMP_PAYLOAD = getattr(settings, 'FILER_DUMP_PAYLOAD', False)  # Whether the filer shall dump the files payload
 


### PR DESCRIPTION
In some production environments, settings are imported as modules. In
this case there is a possibility that DATABASES['default'] will not be
defined when this code is run, in those cases, a keyError will be
thrown. This an attempt to fix this edge case bug.